### PR TITLE
Remove info not used in OARS specification anymore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.flatpak-builder/
+build-dir/

--- a/com.scoutshonour.dtipbijays.appdata.xml
+++ b/com.scoutshonour.dtipbijays.appdata.xml
@@ -21,7 +21,7 @@
     </p>
   </description>
 
-​  <launchable type="desktop-id">com.scoutshonour.dtipbijays.desktop</launchable>
+  <launchable type="desktop-id">com.scoutshonour.dtipbijays.desktop</launchable>
   <releases>
     <release version="1.0" date="2011-04-01" />
   </releases>
@@ -33,8 +33,6 @@
   <content_rating type="oars-1.1">
     <content_attribute id="sex-nudity">intense</content_attribute>
     <content_attribute id="sex-themes">moderate</content_attribute>
-    <content_attribute id="sex-homosexuality">mild</content_attribute>
-    <content_attribute id="sex-appearance">intense</content_attribute>
     <content_attribute id="language-profanity">mild</content_attribute>
     <content_attribute id="language-humor">intense</content_attribute>
   </content_rating>


### PR DESCRIPTION
Fixes #5

---

For now this just removes `sex-homosexuality` and `sex-appearance` attributes for the content rating metadata.
I also fix a small hidden character that was accidentally on the AppStream file.

As an extra, IIRC there's a homophobic character in the game, so it might make sense to also add `<content_attribute id="language-discrimination">moderate</content_attribute>` due to that.
Since I didn't play the game in a long time and I don't plan to play it right now, I would need someone who played it to confirm.

@lionirdeadman You took the time and effort to change the way the app is built so it doesn't uses the bult-in renpy, so I guess you are interested in the game. If so, can you confirm the homophobic character thing?
Also, if you want to maintain this app going forward I would have no problem in having you as co-maintainer. I don't think I can allow you that without asking the Flathub guys first though.

I don't quite remember what is the policy on how updates should be handled, I believe the Flathub guys should review it and only then this should get merged. I will check and, if so, mark the correct person as reviewer.